### PR TITLE
model category vertices

### DIFF
--- a/resources/all/schema.edn
+++ b/resources/all/schema.edn
@@ -49,8 +49,8 @@
                             :description {:type String}
                             :availability {:type (list :ModelInventoryPoolAvailability)}
                             :availableQuantityInDateRange {:type (non-null Int)}
-                            :categories {:type (list :Category)
-                                         :resolve :categories}
+                            :categoryVertices {:type (list :CategoryVertex)
+                                               :resolve :category-vertices}
                             :images {:type (list :Image)
                                      :resolve :images}
                             :attachments {:type (list :Attachment)
@@ -115,6 +115,10 @@
                                                :searchTerm {:type String}}}
                                :images {:type (list :Image)
                                         :resolve :images}}}
+           :CategoryVertex {:fields {:id {:type (non-null :UUID)}
+                                     :label {:type (non-null String)}
+                                     :parents {:type (list :CategoryVertex)
+                                               :resolve :category-vertices}}}
            :Reservation {:fields {:id {:type (non-null :UUID)}
                                   :model {:type (non-null :Model)
                                           :resolve :model}
@@ -202,6 +206,7 @@
                            :orderBy {:type (list :VisitsOrderByInput)}}
                     :type (list :Visit)}
            :models {:args {:categoryIds {:type (list (non-null :UUID))}
+                           :ids {:type (list :UUID)}
                            :inventoryPoolIds {:type (list (non-null :UUID))}
                            :orderBy {:type (list :ModelsOrderByInput)}
                            :searchTerm {:type String}

--- a/resources/all/schema.edn
+++ b/resources/all/schema.edn
@@ -49,6 +49,8 @@
                             :description {:type String}
                             :availability {:type (list :ModelInventoryPoolAvailability)}
                             :availableQuantityInDateRange {:type (non-null Int)}
+                            :categories {:type (list :Category)
+                                         :resolve :categories}
                             :images {:type (list :Image)
                                      :resolve :images}
                             :attachments {:type (list :Attachment)
@@ -101,6 +103,8 @@
                                       :description "A name is either a label for the child-parent connection (if such exists) or the name of the category itself."}
                                :children {:type (list :Category)
                                           :resolve :categories}
+                               :parents {:type (list :Category)
+                                         :resolve :categories}
                                :models {:type :ModelsConnection
                                         :description "Includes only direct ones or all from self and the descendent sub-categories."
                                         :resolve :models-connection

--- a/resources/all/schema.edn
+++ b/resources/all/schema.edn
@@ -102,9 +102,9 @@
                                :name {:type (non-null String)
                                       :description "A name is either a label for the child-parent connection (if such exists) or the name of the category itself."}
                                :children {:type (list :Category)
-                                          :resolve :categories}
+                                          :resolve :child-categories}
                                :parents {:type (list :Category)
-                                         :resolve :categories}
+                                         :resolve :parent-categories}
                                :models {:type :ModelsConnection
                                         :description "Includes only direct ones or all from self and the descendent sub-categories."
                                         :resolve :models-connection

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:3250/borrow/graphql
-# timestamp: Wed Nov 27 2019 16:38:50 GMT+0100 (Central European Standard Time)
+# timestamp: Fri Nov 29 2019 13:50:17 GMT+0100 (Central European Standard Time)
 
 schema {
   query: QueryRoot
@@ -32,6 +32,13 @@ type Category {
   A name is either a label for the child-parent connection (if such exists) or the name of the category itself.
   """
   name: String!
+  parents: [Category]
+}
+
+type CategoryVertex {
+  id: UUID!
+  label: String!
+  parents: [CategoryVertex]
 }
 
 type Contract {
@@ -114,6 +121,7 @@ type Model {
   attachments: [Attachment]
   availability: [ModelInventoryPoolAvailability]
   availableQuantityInDateRange: Int!
+  categoryVertices: [CategoryVertex]
   description: String
   id: UUID!
   images: [Image]
@@ -249,7 +257,7 @@ type QueryRoot {
   contracts(after: String, first: Int, orderBy: [ContractsOrderByInput], states: [ContractStateEnum]): ContractsConnection
   currentUser: CurrentUser!
   inventoryPools: [InventoryPool]
-  models(after: String, categoryIds: [UUID!], endDate: String, first: Int, inventoryPoolIds: [UUID!], orderBy: [ModelsOrderByInput], searchTerm: String, startDate: String): ModelsConnection
+  models(after: String, categoryIds: [UUID!], endDate: String, first: Int, ids: [UUID], inventoryPoolIds: [UUID!], orderBy: [ModelsOrderByInput], searchTerm: String, startDate: String): ModelsConnection
   order(id: UUID!): Order!
   orders(
     after: String

--- a/spec/graphql/models_spec.rb
+++ b/spec/graphql/models_spec.rb
@@ -722,6 +722,20 @@ describe 'models connection' do
       )
     )
 
+    FactoryBot.create(
+      :category,
+      id: 'a377be21-c0dd-47cc-9075-75e0a5fbcab0',
+      name: 'Category A',
+      children: [
+        FactoryBot.create(
+          :category,
+          id: '93c9d9a5-1682-4019-8067-a4f6f34fc949',
+          name: 'Subcategory of A',
+          direct_models: [model]
+        )
+      ]
+    )
+
     q = <<-GRAPHQL
       {
         models(
@@ -759,14 +773,21 @@ describe 'models connection' do
                   quantity
                 }
               }
+              categories {
+                name
+                parents {
+                  name
+                }
+              }
             }
           }
         }
       }
     GRAPHQL
 
-    expect_graphql_result(
-      query(q, user.id),
+    result = query(q, user.id)
+
+    expect_graphql_result(result,
       { models: {
           edges: [
             # recommend
@@ -803,7 +824,14 @@ describe 'models connection' do
                   inventoryPool: { id: '232547a5-5f43-450c-896a-b692275a04ea' },
                   dates: [{ date: '2019-10-24', quantity: 1 }, { date: '2019-10-25', quantity: 1 }]
                 }
-              ]}
+              ]},
+              categories: [
+                { name: 'Subcategory of A',
+                  parents: [
+                    { name: 'Category A' }
+                  ]
+                }
+              ]
             }
           ]
         }

--- a/src/all/leihs/borrow/graphql/queries.clj
+++ b/src/all/leihs/borrow/graphql/queries.clj
@@ -19,6 +19,7 @@
    :availability availability/get
    :categories categories/get-multiple
    :contracts-connection contracts/get-connection
+   :child-categories categories/get-children
    :current-user users/get-current
    :images images/get-multiple
    :inventory-pool inventory-pools/get-one
@@ -27,6 +28,7 @@
    :models-connection models/get-connection
    :order orders/get-one
    :orders-connection orders/get-connection
+   :parent-categories categories/get-parents
    :pool-orders orders/get-multiple-by-pool
    :properties properties/get-multiple
    :reservations reservations/get-multiple

--- a/src/all/leihs/borrow/graphql/queries.clj
+++ b/src/all/leihs/borrow/graphql/queries.clj
@@ -18,6 +18,7 @@
   {:attachments attachments/get-multiple
    :availability availability/get
    :categories categories/get-multiple
+   :category-vertices categories/get-vertices
    :contracts-connection contracts/get-connection
    :child-categories categories/get-children
    :current-user users/get-current

--- a/src/all/leihs/borrow/resources/categories.clj
+++ b/src/all/leihs/borrow/resources/categories.clj
@@ -1,6 +1,8 @@
 (ns leihs.borrow.resources.categories
   (:require [clojure.tools.logging :as log]
             [clojure.java.jdbc :as jdbc]
+            [com.walmartlabs.lacinia :as lacinia]
+            [com.walmartlabs.lacinia.executor :as executor]
             [leihs.core.sql :as sql]
             [leihs.borrow.paths :refer [path]]
             [leihs.borrow.resources.images :as images]
@@ -29,7 +31,9 @@
         (sql/merge-where [:in :model_groups.id ids]))))
 
 (defn get-multiple
-  [{{:keys [tx authenticated-entity]} :request} args value]
+  [{{:keys [tx authenticated-entity]} :request :as context} args value]
+  (def ctx context)
+  (log/debug (executor/selections-seq context))
   (-> base-sqlmap
       (sql/merge-join :model_links
                       [:= :model_groups.id :model_links.model_group_id])
@@ -38,19 +42,62 @@
       (models/merge-reservable-conditions (:id authenticated-entity))
       (extend-based-on-args args)
       (cond-> value
-        (-> (sql/select :model_groups.id
-                        [(sql/call :coalesce
-                                   :model_group_links.label
-                                   :model_groups.name) :name])
-            (sql/merge-join :model_group_links
-                            [:=
-                             :model_groups.id
-                             :model_group_links.child_id])
-            (sql/merge-where [:=
-                              :model_group_links.parent_id
-                              (:id value)])))
+        (#(case (::lacinia/container-type-name context)
+            :Category (cond
+                        (executor/selects-field? context :Category/children)
+                        (-> %
+                            (sql/select :model_groups.id
+                                        [(sql/call :coalesce
+                                                   :model_group_links.label
+                                                   :model_groups.name) :name])
+                            (sql/merge-join :model_group_links
+                                            [:=
+                                             :model_groups.id
+                                             :model_group_links.child_id])
+                            (sql/merge-where [:=
+                                              :model_group_links.parent_id
+                                              (:id value)]))
+                        (:Category/parents) (-> %
+                                                (sql/select :model_groups.id
+                                                            [(sql/call :coalesce
+                                                                       :model_group_links.label
+                                                                       :model_groups.name) :name])
+                                                (sql/merge-join :model_group_links
+                                                                [:=
+                                                                 :model_groups.id
+                                                                 :model_group_links.parent_id])
+                                                (sql/merge-where [:=
+                                                                  :model_group_links.child_id
+                                                                  (:id value)]))
+                        %)
+            :Model (sql/merge-where % [:= :models.id (:id value)]))))
       sql/format
+      ; log/spy
       (->> (jdbc/query tx))))
+
+(comment 
+  (require '[com.walmartlabs.lacinia.executor :as executor])
+  (executor/selections-seq ctx ))
+
+; (comment 
+;   {:com.walmartlabs.lacinia/enable-timing? true,
+;    :com.walmartlabs.lacinia/container-type-name :Category,
+;    :com.walmartlabs.lacinia/selection {:com.walmartlabs.lacinia.parser/arguments-extractor nil,
+;                                        :selections [{:com.walmartlabs.lacinia.parser/arguments-extractor nil, :selections nil, :arguments nil, :reportable-arguments nil, :field :name, :selection-type :field, :alias :name, :leaf? true, :com.walmartlabs.lacinia.parser/prepare-directives? true, :concrete-type? true, :com.walmartlabs.lacinia.parser/needs-prepare? true, :field-definition {:type {:kind :non-null, :type {:kind :root, :type :String}}, :description "A name is either a label for the child-parent connection (if such exists) or the name of the category itself.", :field-name :name, :qualified-name :Category/name, :args {}, :type-name :Category, :resolve #object[com.walmartlabs.lacinia.schema$default_field_resolver$default_resolver__32279 0x3aa88cb0 "com.walmartlabs.lacinia.schema$default_field_resolver$default_resolver__32279@3aa88cb0"], :selector #object[com.walmartlabs.lacinia.schema$assemble_selector$select_non_null__31845 0x1ccb90df "com.walmartlabs.lacinia.schema$assemble_selector$select_non_null__31845@1ccb90df"], :direct-fn :name}, :location {:line 22, :column 7}, :directives []}],
+;                                        :arguments nil,
+;                                        :com.walmartlabs.lacinia.parser/prepare-nested-selections? true,
+;                                        :reportable-arguments nil,
+;                                        :field :parents,
+;                                        :selection-type :field,
+;                                        :alias :parents,
+;                                        :leaf? false,
+;                                        :com.walmartlabs.lacinia.parser/prepare-directives? true,
+;                                        :concrete-type? true,
+;                                        :com.walmartlabs.lacinia.parser/needs-prepare? true,
+;                                        :field-definition {:type {:kind :list, :type {:kind :root, :type :Category}}, :resolve #object[com.walmartlabs.lacinia.schema$wrap_resolver_to_ensure_resolver_result$fn__31806 0x108e8367 "com.walmartlabs.lacinia.schema$wrap_resolver_to_ensure_resolver_result$fn__31806@108e8367"], :field-name :parents, :qualified-name :Category/parents, :args {}, :type-name :Category, :description nil, :selector #object[com.walmartlabs.lacinia.schema$assemble_selector$select_list__31849 0x5003a4c1 "com.walmartlabs.lacinia.schema$assemble_selector$select_list__31849@5003a4c1"], :direct-fn nil},
+;                                        :location {:line 21, :column 5},
+;                                        :directives []}
+;    })
 
 ;#### debug ###################################################################
 ; (logging-config/set-logger! :level :debug)

--- a/src/all/leihs/borrow/resources/categories.clj
+++ b/src/all/leihs/borrow/resources/categories.clj
@@ -1,9 +1,8 @@
 (ns leihs.borrow.resources.categories
   (:require [clojure.tools.logging :as log]
             [clojure.java.jdbc :as jdbc]
-            [com.walmartlabs.lacinia :as lacinia]
-            [com.walmartlabs.lacinia.executor :as executor]
             [leihs.core.sql :as sql]
+            [com.walmartlabs.lacinia :as lacinia]
             [leihs.borrow.paths :refer [path]]
             [leihs.borrow.resources.images :as images]
             [leihs.borrow.resources.models :as models]))
@@ -12,6 +11,10 @@
   (-> (sql/select :model_groups.id [:model_groups.name :name])
       (sql/modifiers :distinct)
       (sql/from :model_groups)
+      (sql/merge-join :model_links
+                      [:= :model_groups.id :model_links.model_group_id])
+      (sql/merge-join :models
+                      [:= :model_links.model_id :models.id])
       (sql/merge-where [:= :model_groups.type "Category"])))
 
 (defn extend-based-on-args [sqlmap {:keys [limit offset ids root-only]}]
@@ -30,74 +33,55 @@
       (cond-> (seq ids)
         (sql/merge-where [:in :model_groups.id ids]))))
 
-(defn get-multiple
-  [{{:keys [tx authenticated-entity]} :request :as context} args value]
-  (def ctx context)
-  (log/debug (executor/selections-seq context))
+(defn get-children
+  [{{:keys [tx authenticated-entity]} :request} args value]
   (-> base-sqlmap
-      (sql/merge-join :model_links
-                      [:= :model_groups.id :model_links.model_group_id])
-      (sql/merge-join :models
-                      [:= :model_links.model_id :models.id])
       (models/merge-reservable-conditions (:id authenticated-entity))
       (extend-based-on-args args)
       (cond-> value
-        (#(case (::lacinia/container-type-name context)
-            :Category (cond
-                        (executor/selects-field? context :Category/children)
-                        (-> %
-                            (sql/select :model_groups.id
-                                        [(sql/call :coalesce
-                                                   :model_group_links.label
-                                                   :model_groups.name) :name])
-                            (sql/merge-join :model_group_links
-                                            [:=
-                                             :model_groups.id
-                                             :model_group_links.child_id])
-                            (sql/merge-where [:=
-                                              :model_group_links.parent_id
-                                              (:id value)]))
-                        (:Category/parents) (-> %
-                                                (sql/select :model_groups.id
-                                                            [(sql/call :coalesce
-                                                                       :model_group_links.label
-                                                                       :model_groups.name) :name])
-                                                (sql/merge-join :model_group_links
-                                                                [:=
-                                                                 :model_groups.id
-                                                                 :model_group_links.parent_id])
-                                                (sql/merge-where [:=
-                                                                  :model_group_links.child_id
-                                                                  (:id value)]))
-                        %)
-            :Model (sql/merge-where % [:= :models.id (:id value)]))))
+        (-> (sql/select :model_groups.id
+                        [(sql/call :coalesce
+                                   :model_group_links.label
+                                   :model_groups.name) :name])
+            (sql/merge-join :model_group_links
+                            [:=
+                             :model_groups.id
+                             :model_group_links.child_id])
+            (sql/merge-where [:=
+                              :model_group_links.parent_id
+                              (:id value)])))
       sql/format
-      ; log/spy
       (->> (jdbc/query tx))))
 
-(comment 
-  (require '[com.walmartlabs.lacinia.executor :as executor])
-  (executor/selections-seq ctx ))
+(defn get-parents
+  [{{:keys [tx authenticated-entity]} :request} args value]
+  (-> base-sqlmap
+      (sql/select :model_groups.id
+                  [(sql/call :coalesce
+                             :model_group_links.label
+                             :model_groups.name) :name])
+      (sql/merge-join :model_group_links
+                      [:=
+                       :model_groups.id
+                       :model_group_links.parent_id])
+      (sql/merge-where [:=
+                        :model_group_links.child_id
+                        (:id value)])
+      (models/merge-reservable-conditions (:id authenticated-entity))
+      (extend-based-on-args args)
+      sql/format
+      (->> (jdbc/query tx))))
 
-; (comment 
-;   {:com.walmartlabs.lacinia/enable-timing? true,
-;    :com.walmartlabs.lacinia/container-type-name :Category,
-;    :com.walmartlabs.lacinia/selection {:com.walmartlabs.lacinia.parser/arguments-extractor nil,
-;                                        :selections [{:com.walmartlabs.lacinia.parser/arguments-extractor nil, :selections nil, :arguments nil, :reportable-arguments nil, :field :name, :selection-type :field, :alias :name, :leaf? true, :com.walmartlabs.lacinia.parser/prepare-directives? true, :concrete-type? true, :com.walmartlabs.lacinia.parser/needs-prepare? true, :field-definition {:type {:kind :non-null, :type {:kind :root, :type :String}}, :description "A name is either a label for the child-parent connection (if such exists) or the name of the category itself.", :field-name :name, :qualified-name :Category/name, :args {}, :type-name :Category, :resolve #object[com.walmartlabs.lacinia.schema$default_field_resolver$default_resolver__32279 0x3aa88cb0 "com.walmartlabs.lacinia.schema$default_field_resolver$default_resolver__32279@3aa88cb0"], :selector #object[com.walmartlabs.lacinia.schema$assemble_selector$select_non_null__31845 0x1ccb90df "com.walmartlabs.lacinia.schema$assemble_selector$select_non_null__31845@1ccb90df"], :direct-fn :name}, :location {:line 22, :column 7}, :directives []}],
-;                                        :arguments nil,
-;                                        :com.walmartlabs.lacinia.parser/prepare-nested-selections? true,
-;                                        :reportable-arguments nil,
-;                                        :field :parents,
-;                                        :selection-type :field,
-;                                        :alias :parents,
-;                                        :leaf? false,
-;                                        :com.walmartlabs.lacinia.parser/prepare-directives? true,
-;                                        :concrete-type? true,
-;                                        :com.walmartlabs.lacinia.parser/needs-prepare? true,
-;                                        :field-definition {:type {:kind :list, :type {:kind :root, :type :Category}}, :resolve #object[com.walmartlabs.lacinia.schema$wrap_resolver_to_ensure_resolver_result$fn__31806 0x108e8367 "com.walmartlabs.lacinia.schema$wrap_resolver_to_ensure_resolver_result$fn__31806@108e8367"], :field-name :parents, :qualified-name :Category/parents, :args {}, :type-name :Category, :description nil, :selector #object[com.walmartlabs.lacinia.schema$assemble_selector$select_list__31849 0x5003a4c1 "com.walmartlabs.lacinia.schema$assemble_selector$select_list__31849@5003a4c1"], :direct-fn nil},
-;                                        :location {:line 21, :column 5},
-;                                        :directives []}
-;    })
+(defn get-multiple
+  [{{:keys [tx authenticated-entity]} :request :as context} args value]
+  (-> base-sqlmap
+      (models/merge-reservable-conditions (:id authenticated-entity))
+      (extend-based-on-args args)
+      (cond-> (and value
+                   (= (::lacinia/container-type-name context) :Model))
+        (sql/merge-where [:= :models.id (:id value)]))
+      sql/format
+      (->> (jdbc/query tx))))
 
 ;#### debug ###################################################################
 ; (logging-config/set-logger! :level :debug)

--- a/src/all/leihs/borrow/resources/models.clj
+++ b/src/all/leihs/borrow/resources/models.clj
@@ -150,7 +150,7 @@
       (merge-category-ids-conditions category-ids))))
 
 (defn get-multiple-sqlmap [{{:keys [tx authenticated-entity]} :request :as context}
-                           {:keys [limit offset direct-only order-by search-term]}
+                           {:keys [limit offset direct-only order-by search-term ids]}
                            value]
   (-> base-sqlmap
       (cond-> (= (::lacinia/container-type-name context) :Model)
@@ -158,6 +158,8 @@
       (cond-> (= (::lacinia/container-type-name context) :Category)
         (merge-categories-conditions tx value direct-only))
       (merge-reservable-conditions (:id authenticated-entity))
+      (cond-> ids
+        (sql/merge-where [:in :models.id ids]))
       (cond-> search-term
         (merge-search-conditions search-term))
       (cond-> (seq order-by)


### PR DESCRIPTION
Beispiel für model `fa0b393d-3eb5-5ea3-970c-3a5f0f15afb6`:

```yaml
_note: use (label from parent) OR (own label)
category_vertices:
  - id: 3c6760cb-279b-5170-a78c-f3c06a6eb5cd
    label: Profil-Scheinwerfer 
    parent:
      id: b5afb6ba-fa9f-5ba2-95f3-51519fb8a2dc
      label: Licht für Veranstaltungen
  - id: fc9399dc-569f-59d8-9da5-ca05bd5fbb44
    label: Mini Scheinwerfer
    parent:
      id: b5afb6ba-fa9f-5ba2-95f3-51519fb8a2dc
      label: Licht für Veranstaltungen
  - id: fc9399dc-569f-59d8-9da5-ca05bd5fbb44
    label: Mini Scheinwerfer
    parent:
      id: 87370cf9-460f-574b-873e-a26fe42f7ddd
      label: Andere Beleuchtungssysteme	
```